### PR TITLE
Fix bug: authorization failed when using token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,9 +92,10 @@ function getFolderData(folder: Folder, callback: (folders: Folder[], files: File
     if (query.git === 'gitlab') {
         url = `https://${query.gitlab}/api/v4/projects/${query.id}/repository/tree?per_page=1000&ref=master&path=${encodeURI(getPath(folder))}`
     } else {
-        url = `https://api.github.com/repos/${query.github}/contents/${encodeURI(getPath(folder))}${query.token ? `?access_token=${query.token}` : ''}`
+        url = `https://api.github.com/repos/${query.github}/contents/${encodeURI(getPath(folder))}`
     }
     request.open('GET', url)
+    request.setRequestHeader("Authorization", `token ${query.token}`)
     request.onreadystatechange = function () {
         if (request.readyState === 4 && request.status === 200) {
             const tree = JSON.parse(request.responseText)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,9 @@ function getFolderData(folder: Folder, callback: (folders: Folder[], files: File
         url = `https://api.github.com/repos/${query.github}/contents/${encodeURI(getPath(folder))}`
     }
     request.open('GET', url)
-    request.setRequestHeader("Authorization", `token ${query.token}`)
+    if (query.token){
+        request.setRequestHeader("Authorization", `token ${query.token}`)
+    }
     request.onreadystatechange = function () {
         if (request.readyState === 4 && request.status === 200) {
             const tree = JSON.parse(request.responseText)


### PR DESCRIPTION
Since Github [deprecated API authentication through query parameters](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/) in September 8 2021, the program can't access repo with a token. This commit fix the problem by adding token to the request header.